### PR TITLE
Imported JS calls don't handle differing arities.

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1014,7 +1014,7 @@ Note: Exported Functions do not have a \[[Construct]] method and thus it is not 
         1. If |method| is undefined, [=throw=] a {{TypeError}}.
         1. Let |values| be ? [=IterableToList=](|ret|, |method|).
         1. Let |wasmValues| be a new, empty [=list=].
-        1. Assert: |values| and |results| have the same length.
+        1. If |values| and |results| do not have the same length, throw a {{TypeError}}.
         1. For each |value| and |resultType| in |values| and |results|, paired linearly,
             1. [=list/Append=] [=ToWebAssemblyValue=](|value|, |resultType|) to |wasmValues|.
         1. Return |wasmValues|.


### PR DESCRIPTION
Right now there is a spec assert that host call's iterable result and wasm have the same arity. There's no guarantee this is true. Instead we should probably throw a type error if they don't match. 

Alternatively, we could do the more JS-y approach and allow the arity of result to be at least the arity of the expected signature. Although, if we did that we should also allow the arity to be less and call `ToWebAssemblyValue(undefined, results[i])` on any results past the end.

I also normalized the wording around what happens when an exception is thrown in the host call does to the surrounding Wasm code. Previously , the wording was a little vague.