### PR TITLE
[spec] fixed that functype outs is still a optional

### DIFF
--- a/document/core/valid/types.rst
+++ b/document/core/valid/types.rst
@@ -96,7 +96,7 @@ Function Types
 .. math::
    \frac{
    }{
-     \vdashfunctype [t_1^\ast] \to [t_2^?] \ok
+     \vdashfunctype [t_1^\ast] \to [t_2^\ast] \ok
    }
 
 


### PR DESCRIPTION
I believed this is a typo?