### PR TITLE
Use the intended variable in 'run a host function'.

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1007,10 +1007,10 @@ Note: Exported Functions do not have a \[[Construct]] method and thus it is not 
     1. For each |arg| in |arguments|,
         1. [=list/Append=] ! [=ToJSValue=](|arg|) to |jsArguments|.
     1. Let |ret| be ? [=Call=](|func|, undefined, |jsArguments|).
-    1. If |results| [=list/empty=], return undefined.
+    1. If |results| [=list/is empty=], return undefined.
     1. Otherwise, if |results|'s [=list/size=] is 1, return ? [=ToWebAssemblyValue=](|ret|, |results|[0]).
     1. Otherwise,
-        1. Let |method| be ? [=GetMethod=](|results|, @@iterator).
+        1. Let |method| be ? [=GetMethod=](|ret|, [=@@iterator=]).
         1. If |method| is undefined, [=throw=] a {{TypeError}}.
         1. Let |values| be ? [=IterableToList=](|ret|, |method|).
         1. Let |wasmValues| be a new, empty [=list=].


### PR DESCRIPTION
This also fixes nearby cross-references.

Fixes #24.