### PR TITLE
[js-api] Fix minor bugs in 'run a host function'.

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1000,15 +1000,14 @@ Note: Exported Functions do not have a \[[Construct]] method and thus it is not 
   To <dfn>run a host function</dfn> from the JavaScript object |func|, type |functype|, and [=list=] of [=WebAssembly values=] |arguments|, perform the following steps:
 
     1. Let [|parameters|] → [|results|] be |functype|.
-    1. Assert: |results|'s [=list/size=] is at most one.
     1. If either |parameters| or |results| contains [=𝗂𝟨𝟦=], throw a {{TypeError}}.
     1. Let |arguments| be a [=list=] of the arguments of the invocation of this function.
     1. Let |jsArguments| be an empty [=list=].
     1. For each |arg| in |arguments|,
         1. [=list/Append=] ! [=ToJSValue=](|arg|) to |jsArguments|.
     1. Let |ret| be ? [=Call=](|func|, undefined, |jsArguments|).
-    1. If |results| [=list/is empty=], return undefined.
-    1. Otherwise, if |results|'s [=list/size=] is 1, return ? [=ToWebAssemblyValue=](|ret|, |results|[0]).
+    1. If |results| [=list/is empty=], return « ».
+    1. Otherwise, if |results|'s [=list/size=] is 1, return « ? [=ToWebAssemblyValue=](|ret|, |results|[0]) ».
     1. Otherwise,
         1. Let |method| be ? [=GetMethod=](|ret|, [=@@iterator=]).
         1. If |method| is undefined, [=throw=] a {{TypeError}}.


### PR DESCRIPTION
In particular, remove an invalid assertion and take into account that
WebAssembly functions always return a list of results.