### PR TITLE
Add loop and block assert_invalid tests

### DIFF
--- a/test/core/block.wast
+++ b/test/core/block.wast
@@ -1470,6 +1470,12 @@
   ))
   "type mismatch"
 )
+(assert_invalid
+  (module (func $type-param-nested-poly-num-nondrop
+    (unreachable) (block (param i32))
+  ))
+  "type mismatch"
+)
 
 (assert_malformed
   (module quote "(func (param i32) (result i32) block (param $x i32) end)")

--- a/test/core/loop.wast
+++ b/test/core/loop.wast
@@ -766,22 +766,22 @@
   "type mismatch"
 )
 (assert_invalid
-  (module (func $type-param-brif-void-vs-num
-        (f32.const 0)
-        (loop (param i32)
-            (drop)
-            (br_if 0 (f32.const 1))
-        )
+  (module (func $type-param-void-vs-num
+    (f32.const 0)
+    (loop (param i32)
+      (drop)
+      (br_if 0 (f32.const 1))
+    )
   ))
   "type mismatch"
 )
 (assert_invalid
-  (module (func $type-param-brif-wrong-vs-num
-        (f32.const 0)
-        (loop (param i32)
-            (i64.const 0)
-            (br_if 0 (f32.const 1))
-        )
+  (module (func $type-param-float-vs-num
+    (f32.const 0)
+    (loop (param i32)
+      (f64.const 0)
+      (br_if 0 (f32.const 1))
+    )
   ))
   "type mismatch"
 )

--- a/test/core/loop.wast
+++ b/test/core/loop.wast
@@ -765,6 +765,26 @@
   ))
   "type mismatch"
 )
+(assert_invalid
+  (module (func $type-param-brif-void-vs-num
+        (f32.const 0)
+        (loop (param i32)
+            (drop)
+            (br_if 0 (f32.const 1))
+        )
+  ))
+  "type mismatch"
+)
+(assert_invalid
+  (module (func $type-param-brif-wrong-vs-num
+        (f32.const 0)
+        (loop (param i32)
+            (i64.const 0)
+            (br_if 0 (f32.const 1))
+        )
+  ))
+  "type mismatch"
+)
 
 (assert_malformed
   (module quote "(func (param i32) (result i32) loop (param $x i32) end)")


### PR DESCRIPTION
Add some assert_invalid tests for:
- invalid block return types when polymorphic stack present (https://github.com/bytecodealliance/wasmparser/pull/193)
- invalid loop param types when br_if is used (https://github.com/bytecodealliance/wasmparser/pull/195)
