### PR TITLE
Check multiple returns in generated JS code

### DIFF
--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -120,22 +120,32 @@ function assert_exhaustion(action) {
   throw new Error("Wasm resource exhaustion expected");
 }
 
-function assert_return(action, expected) {
+function assert_return(action, ...expected) {
   let actual = action();
-  switch (expected) {
-    case "nan:canonical":
-    case "nan:arithmetic":
-    case "nan:any":
-      // Note that JS can't reliably distinguish different NaN values,
-      // so there's no good way to test that it's a canonical NaN.
-      if (!Number.isNaN(actual)) {
-        throw new Error("Wasm return value NaN expected, got " + actual);
-      };
-      return;
-    default:
-      if (!Object.is(actual, expected)) {
-        throw new Error("Wasm return value " + expected + " expected, got " + actual);
-      };
+  if (actual === undefined) {
+    actual = [];
+  } else if (!Array.isArray(actual)) {
+    actual = [actual];
+  }
+  if (actual.length !== expected.length) {
+    throw new Error(expected.length + " value(s) expected, got " + actual.length);
+  }
+  for (let i = 0; i < actual.length; ++i) {
+    switch (expected[i]) {
+      case "nan:canonical":
+      case "nan:arithmetic":
+      case "nan:any":
+        // Note that JS can't reliably distinguish different NaN values,
+        // so there's no good way to test that it's a canonical NaN.
+        if (!Number.isNaN(actual[i])) {
+          throw new Error("Wasm return value NaN expected, got " + actual);
+        };
+        return;
+      default:
+        if (!Object.is(actual[i], expected[i])) {
+          throw new Error("Wasm return value " + expected[i] + " expected, got " + actual[i]);
+        };
+    }
   }
 }
 |}

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -138,7 +138,7 @@ function assert_return(action, ...expected) {
         // Note that JS can't reliably distinguish different NaN values,
         // so there's no good way to test that it's a canonical NaN.
         if (!Number.isNaN(actual[i])) {
-          throw new Error("Wasm return value NaN expected, got " + actual);
+          throw new Error("Wasm return value NaN expected, got " + actual[i]);
         };
         return;
       default:


### PR DESCRIPTION
This change modifies `assert_return`. After the Wasm function is
invoked, the result will either be `undefined`, a JS `Number`, or a JS
`Array`. It's simpler to treat them all as an array, with `undefined`
representing an empty array, and `Number` representing an array with one
element.

We don't check for `Number` here, since as soon as we add support for
the reference-types proposal, a scalar result may be an `Object` too.

Fixes issue #44.